### PR TITLE
refactor: split command to allow for further commands

### DIFF
--- a/cmd/gitops-commit/main.go
+++ b/cmd/gitops-commit/main.go
@@ -2,82 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/gsdevme/gitops-commit/internal/pkg/gitops"
-	"github.com/spf13/cobra"
-	"io/ioutil"
+	"github.com/gsdevme/gitops-commit/internal/app/gitops-commit/cmd"
 	"os"
-	"strings"
 )
 
-func NewRootCommand() *cobra.Command {
-	c := cobra.Command{
-		Use: "gitops-commit",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			key := cmd.Flag("key").Value.String()
-			email := cmd.Flag("email").Value.String()
-			newVersion := cmd.Flag("version").Value.String()
-			notation := cmd.Flag("notation").Value.String()
-			repo := strings.TrimRight(cmd.Flag("repo").Value.String(), "/")
-			file := strings.TrimLeft(cmd.Flag("file").Value.String(), "/")
-
-			options, c, err := gitops.NewGitOptions(key)
-
-			if len(email) > 0 {
-				options.Email = email
-			}
-
-			if err != nil {
-				return err
-			}
-
-			defer c()
-
-			r, err := gitops.CloneRepository(options, repo)
-
-			if err != nil {
-				return fmt.Errorf("failed to clone repo %s: %w", repo, err)
-			}
-
-			filename := fmt.Sprintf("%s/%s", options.WorkingDirectory, file)
-
-			f, err := ioutil.ReadFile(filename)
-
-			if err != nil {
-				return fmt.Errorf("cannot read file: %w", err)
-			}
-
-			version, err := gitops.ReadCurrentVersion(f, notation)
-			if err != nil {
-				return fmt.Errorf("cannot read current version deployed: %w", err)
-			}
-
-			err = gitops.WriteVersion(f, version, newVersion, filename)
-			if err != nil {
-				return fmt.Errorf("cannot write new version: %w", err)
-			}
-
-			gitops.PushVersion(r, options, file, fmt.Sprintf("ci: update tag to %s", newVersion))
-
-			return nil
-		},
-	}
-
-	c.Flags().String("notation", "", "The yaml path in dot notation i.e. image.tag")
-	c.Flags().String("email", "", "The email address of the commit")
-	c.Flags().String("version", "", "The semver version you want to deploy i.e. v1.1.2")
-	c.Flags().String("key", fmt.Sprintf("%s/.ssh/id_rsa", os.Getenv("HOME")), "Absolute path to the private key")
-	c.Flags().String("repo", "gsdevme/test", "The org/repo path")
-	c.Flags().String("file", "/deployments/values.yaml", "The relative path in the repository to the file")
-
-	_ = c.MarkFlagRequired("notation")
-	_ = c.MarkFlagRequired("tag")
-	_ = c.MarkFlagRequired("file")
-
-	return &c
-}
-
 func main() {
-	if err := NewRootCommand().Execute(); err != nil {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/internal/app/gitops-commit/cmd/root.go
+++ b/internal/app/gitops-commit/cmd/root.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func NewRootCommand() *cobra.Command {
+	c := cobra.Command{
+		Use:   "Gitops Commit",
+		Short: "A simple tool to mutate a version within a yaml file to trigger gitops operations",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.HelpFunc()(cmd, args)
+		},
+	}
+
+	c.AddCommand(newRunCommand())
+
+	return &c
+}

--- a/internal/app/gitops-commit/cmd/run.go
+++ b/internal/app/gitops-commit/cmd/run.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/gsdevme/gitops-commit/internal/pkg/gitops"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+func newRunCommand() *cobra.Command {
+	c := cobra.Command{
+		Use: "run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := cmd.Flag("key").Value.String()
+			email := cmd.Flag("email").Value.String()
+			newVersion := cmd.Flag("version").Value.String()
+			notation := cmd.Flag("notation").Value.String()
+			repo := strings.TrimRight(cmd.Flag("repo").Value.String(), "/")
+			file := strings.TrimLeft(cmd.Flag("file").Value.String(), "/")
+
+			options, c, err := gitops.NewGitOptions(key)
+
+			if len(email) > 0 {
+				options.Email = email
+			}
+
+			if err != nil {
+				return err
+			}
+
+			defer c()
+
+			err = gitops.DeployVersionHandler(gitops.DeployVersionCommand{
+				GitOptions: *options,
+				Repository: repo,
+				Notation:   notation,
+				File:       file,
+				Version:    newVersion,
+			})
+
+			return err
+		},
+	}
+
+	c.Flags().String("notation", "", "The yaml path in dot notation i.e. image.tag")
+	c.Flags().String("email", "", "The email address of the commit")
+	c.Flags().String("version", "", "The semver version you want to deploy i.e. v1.1.2")
+	c.Flags().String("key", fmt.Sprintf("%s/.ssh/id_rsa", os.Getenv("HOME")), "Absolute path to the private key")
+	c.Flags().String("repo", "gsdevme/test", "The org/repo path")
+	c.Flags().String("file", "/deployments/values.yaml", "The relative path in the repository to the file")
+
+	_ = c.MarkFlagRequired("notation")
+	_ = c.MarkFlagRequired("tag")
+	_ = c.MarkFlagRequired("file")
+
+	return &c
+}

--- a/internal/pkg/gitops/git.go
+++ b/internal/pkg/gitops/git.go
@@ -24,7 +24,7 @@ func NewGitOptions(key string) (*GitOptions, func(), error) {
 		return nil, nil, err
 	}
 
-	keys, err := GetPasswordlessKey(key)
+	keys, err := getPasswordlessKey(key)
 
 	if err != nil {
 		return nil, nil, err
@@ -83,7 +83,7 @@ func PushVersion(r *git.Repository, options *GitOptions, file string, message st
 	}
 }
 
-func GetPasswordlessKey(key string) (*ssh.PublicKeys, error) {
+func getPasswordlessKey(key string) (*ssh.PublicKeys, error) {
 	publicKeys, err := ssh.NewPublicKeysFromFile("git", key, "")
 	if err != nil {
 		return nil, fmt.Errorf("private/public key invalid: %w", err)
@@ -92,7 +92,7 @@ func GetPasswordlessKey(key string) (*ssh.PublicKeys, error) {
 	return publicKeys, nil
 }
 
-func CloneRepository(o *GitOptions, r string) (*git.Repository, error) {
+func cloneRepository(o *GitOptions, r string) (*git.Repository, error) {
 
 	return git.PlainClone(o.WorkingDirectory, false, &git.CloneOptions{
 		Auth:         &o.Keys,

--- a/internal/pkg/gitops/handler.go
+++ b/internal/pkg/gitops/handler.go
@@ -1,0 +1,44 @@
+package gitops
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+type DeployVersionCommand struct {
+	GitOptions GitOptions
+	Repository string
+	Notation   string
+	File       string
+	Version    string
+}
+
+func DeployVersionHandler(c DeployVersionCommand) error {
+	r, err := cloneRepository(&c.GitOptions, c.Repository)
+
+	if err != nil {
+		return fmt.Errorf("failed to clone repo %s: %w", c.Repository, err)
+	}
+
+	filename := fmt.Sprintf("%s/%s", c.GitOptions.WorkingDirectory, c.File)
+
+	f, err := ioutil.ReadFile(filename)
+
+	if err != nil {
+		return fmt.Errorf("cannot read file: %w", err)
+	}
+
+	version, err := ReadCurrentVersion(f, c.Notation)
+	if err != nil {
+		return fmt.Errorf("cannot read current version deployed: %w", err)
+	}
+
+	err = WriteVersion(f, version, c.Version, filename)
+	if err != nil {
+		return fmt.Errorf("cannot write new version: %w", err)
+	}
+
+	PushVersion(r, &c.GitOptions, c.File, fmt.Sprintf("ci: update tag to %s", c.Version))
+
+	return nil
+}


### PR DESCRIPTION
BREAKING CHANGE: you now need to execute `run` for the main cmd