### PR TITLE
feat(slack): add slack command for named configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,26 @@ gitops operations i.e. update a helm value
 
 ## Usage
 
+Within the `~/.gitops-commit/manifest.yaml`
+
+```yaml
+repositories:
+  # Example of what the fields map to
+  # https://github.com/gsdevme/test/blob/master/deployments/foo/values.yaml
+  # https://github.com/gsdevme/test
+  - name: my-app-test
+    repository: gsdevme/test
+    file: deployments/test/values.yaml
+    notation: image.tag
+  - name: my-app-test
+    repository: gsdevme/test
+    file: deployments/prod/values.yaml
+    notation: image.tag
+    branch: master
+```
+
+---
+
 ```bash
 $: gitops-commit  -h                                                                                    
 Usage:
@@ -32,3 +52,4 @@ Flags:
 - Github only
 - YAML only
 - Semver tag only
+- Passwordless keys only

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require (
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/gorilla/mux v1.8.0
+	github.com/slack-go/slack v0.9.5
 	github.com/spf13/cobra v1.2.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
@@ -15,11 +17,13 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -163,6 +165,10 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -232,6 +238,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -249,6 +256,8 @@ github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/slack-go/slack v0.9.5 h1:j7uOUDowybWf9eSgZg/AbGx6J1OPJB6SE8Z5dNl6Mtw=
+github.com/slack-go/slack v0.9.5/go.mod h1:wWL//kk0ho+FcQXcBTmEafUI5dz4qz5f4mMk8oIkioQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=

--- a/internal/app/gitops-commit/cmd/root.go
+++ b/internal/app/gitops-commit/cmd/root.go
@@ -12,6 +12,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	c.AddCommand(newRunCommand())
+	c.AddCommand(newServeCommand())
 
 	return &c
 }

--- a/internal/app/gitops-commit/cmd/run.go
+++ b/internal/app/gitops-commit/cmd/run.go
@@ -19,7 +19,13 @@ func newRunCommand() *cobra.Command {
 			repo := strings.TrimRight(cmd.Flag("repo").Value.String(), "/")
 			file := strings.TrimLeft(cmd.Flag("file").Value.String(), "/")
 
-			options, c, err := gitops.NewGitOptions(key)
+			keys, err := gitops.GetPasswordlessKey(key)
+
+			if err != nil {
+				return err
+			}
+
+			options, c, err := gitops.NewGitOptions(keys)
 
 			if len(email) > 0 {
 				options.Email = email

--- a/internal/app/gitops-commit/cmd/serve.go
+++ b/internal/app/gitops-commit/cmd/serve.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/gsdevme/gitops-commit/internal/app/gitops-commit/slackhttp"
+	"github.com/gsdevme/gitops-commit/internal/pkg/gitops"
+	"github.com/spf13/cobra"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func newServeCommand() *cobra.Command {
+	c := cobra.Command{
+		Use: "serve",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			port := cmd.Flag("port").Value.String()
+			key := cmd.Flag("key").Value.String()
+			file := cmd.Flag("manifest").Value.String()
+
+			keys, err := gitops.GetPasswordlessKey(key)
+
+			if err != nil {
+				return err
+			}
+
+			manifest, err := slackhttp.LoadManifest(file)
+			if err != nil {
+				return err
+			}
+
+			r := manifest.GetRegistry()
+
+			s := slackhttp.NewSlackCommandServer(*r, keys)
+			server := &http.Server{
+				Addr:         fmt.Sprintf(":%s", port),
+				Handler:      s,
+				ReadTimeout:  3 * time.Second,
+				WriteTimeout: 5 * time.Second,
+				ConnState: func(conn net.Conn, state http.ConnState) {
+					//fmt.Fprintf(os.Stdout, "%s - %s\n", conn.RemoteAddr(), state.String())
+				},
+			}
+
+			fmt.Fprintf(os.Stdout, "Listening on http://127.0.0.1:%s", port)
+
+			defer server.Close()
+
+			return server.ListenAndServe()
+		},
+	}
+
+	p := 8080
+
+	if len(os.Getenv("PORT")) > 0 {
+		envPort, err := strconv.Atoi(os.Getenv("PORT"))
+
+		if err != nil {
+			p = envPort
+		}
+	}
+
+	c.Flags().Int("port", p, "The web server port to listen on")
+	c.Flags().String("key", fmt.Sprintf("%s/.ssh/id_rsa", os.Getenv("HOME")), "Absolute path to the private key")
+	c.Flags().String("manifest", fmt.Sprintf("%s/.gitops-commit/manifest.yaml", os.Getenv("HOME")), "Absolute path to the manifest")
+
+	return &c
+}

--- a/internal/app/gitops-commit/slackhttp/handler.go
+++ b/internal/app/gitops-commit/slackhttp/handler.go
@@ -1,0 +1,105 @@
+package slackhttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gsdevme/gitops-commit/internal/pkg/gitops"
+	"github.com/slack-go/slack"
+	"net/http"
+	"strings"
+)
+
+func (s *server) handleSlackCommand(registry *NamedRepositoryRegistry) func(http.ResponseWriter, slack.SlashCommand) {
+	return func(w http.ResponseWriter, sl slack.SlashCommand) {
+		text := strings.Split(sl.Text, " ")
+
+		if len(text) < 3 || len(text) > 3 {
+			sendEphemeralMsg("Incorrect usage, expected /gitops-commit [command] [name] [tag]", w)
+
+			return
+		}
+
+		switch text[0] {
+		case "deploy":
+			deploy(s, w, registry, text[1], text[2])
+
+			return
+		}
+	}
+}
+
+func deploy(s *server, w http.ResponseWriter, registry *NamedRepositoryRegistry, name string, version string) {
+
+	r, err := registry.findNamedRepository(name)
+
+	if err != nil {
+		sendEphemeralMsg(fmt.Sprintf("Unknown named repository, cannot handle \"%s\", availabe options (%s)", name, registry.getNamesFlattened()), w)
+
+		return
+	}
+
+	if len(version) != 7 {
+		sendEphemeralMsg(fmt.Sprintf("version does not look semver? %s", version), w)
+
+		return
+	}
+
+	options, f, err := gitops.NewGitOptions(s.keys)
+	if err != nil {
+		return
+	}
+
+	defer f()
+
+	command := gitops.DeployVersionCommand{
+		GitOptions: *options,
+		Repository: r.Repository,
+		Notation:   r.Notation,
+		File:       r.File,
+		Version:    version,
+	}
+
+	go func() {
+		err = gitops.DeployVersionHandler(command)
+		if err != nil {
+			sendEphemeralMsg(fmt.Sprintf("failed to deploy: %s", err), w)
+
+			return
+		}
+	}()
+
+	params := &slack.Msg{
+		Text:         fmt.Sprintf(":alert: Deploying tag `%s` to `%s`:`%s`", version, r.Repository, r.File),
+		ResponseType: slack.ResponseTypeInChannel,
+	}
+	b, err := json.Marshal(params)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(b)
+
+	if err != nil {
+		return
+	}
+}
+
+func sendEphemeralMsg(m string, w http.ResponseWriter) {
+	b, err := json.Marshal(slack.Msg{
+		Text:         m,
+		ResponseType: slack.ResponseTypeEphemeral,
+	})
+	if err != nil {
+		fmt.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	_, err = w.Write(b)
+	if err != nil {
+		return
+	}
+}

--- a/internal/app/gitops-commit/slackhttp/manifest.go
+++ b/internal/app/gitops-commit/slackhttp/manifest.go
@@ -1,0 +1,59 @@
+package slackhttp
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"io/ioutil"
+)
+
+type Manifest struct {
+	registry *NamedRepositoryRegistry
+}
+
+type manifestYaml struct {
+	Repositories []struct {
+		Name       string `yaml:"name"`
+		File       string `yaml:"file"`
+		Notation   string `yaml:"notation"`
+		Repository string `yaml:"repository"`
+		Branch     string `yaml:"branch,omitempty"`
+	} `yaml:"repositories"`
+}
+
+func (m *Manifest) GetRegistry() *NamedRepositoryRegistry {
+	return m.registry
+}
+
+func LoadManifest(f string) (*Manifest, error) {
+	m := Manifest{
+		registry: NewNamedRepositoryRegistry(),
+	}
+
+	d, err := ioutil.ReadFile(f)
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot read yaml file: %w", err)
+	}
+
+	var manifest manifestYaml
+
+	err = yaml.Unmarshal(d, &manifest)
+
+	if err != nil {
+		return nil, fmt.Errorf("invalid yaml file: %w", err)
+	}
+
+	var branch string
+
+	for _, r := range manifest.Repositories {
+		branch = "master"
+
+		if len(r.Branch) > 0 {
+			branch = r.Branch
+		}
+
+		m.registry.Add(r.Name, r.Repository, r.File, r.Notation, branch)
+	}
+
+	return &m, nil
+}

--- a/internal/app/gitops-commit/slackhttp/middleware.go
+++ b/internal/app/gitops-commit/slackhttp/middleware.go
@@ -1,0 +1,35 @@
+package slackhttp
+
+import (
+	"github.com/slack-go/slack"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func (s *server) SlackCommandMiddleware(next func(w http.ResponseWriter, s slack.SlashCommand)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		verifier, err := slack.NewSecretsVerifier(r.Header, s.slackSecret)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		r.Body = ioutil.NopCloser(io.TeeReader(r.Body, &verifier))
+		s, err := slack.SlashCommandParse(r)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		if err = verifier.Ensure(); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		next(w, s)
+	}
+}

--- a/internal/app/gitops-commit/slackhttp/model.go
+++ b/internal/app/gitops-commit/slackhttp/model.go
@@ -1,0 +1,51 @@
+package slackhttp
+
+import "fmt"
+
+type NamedRepository struct {
+	Name       string
+	Repository string
+	File       string
+	Notation   string
+	Branch     string
+}
+
+type NamedRepositoryRegistry struct {
+	r *[]NamedRepository
+}
+
+func NewNamedRepositoryRegistry() *NamedRepositoryRegistry {
+	return &NamedRepositoryRegistry{
+		r: &[]NamedRepository{},
+	}
+}
+
+func (c *NamedRepositoryRegistry) Add(name string, r string, f string, n string, b string) {
+	*c.r = append(*c.r, NamedRepository{
+		Name:       name,
+		Repository: r,
+		File:       f,
+		Notation:   n,
+		Branch:     b,
+	})
+}
+
+func (c *NamedRepositoryRegistry) findNamedRepository(n string) (*NamedRepository, error) {
+	for _, r := range *c.r {
+		if r.Name == n {
+			return &r, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no named repository found for %s", n)
+}
+
+func (c *NamedRepositoryRegistry) getNamesFlattened() string {
+	var names string
+
+	for _, r := range *c.r {
+		names += r.Name + ","
+	}
+
+	return names[:len(names)-1]
+}

--- a/internal/app/gitops-commit/slackhttp/routes.go
+++ b/internal/app/gitops-commit/slackhttp/routes.go
@@ -1,0 +1,14 @@
+package slackhttp
+
+func (s *server) routes() {
+
+	s.router.HandleFunc("/ping", s.handleHealthCheck())
+	s.router.HandleFunc("/healthz", s.handleHealthCheck())
+
+	s.router.HandleFunc(
+		"/slack_command",
+		s.SlackCommandMiddleware(s.handleSlackCommand(s.registry)),
+	).Methods("POST")
+
+	s.router.HandleFunc("/", s.handleNotFound())
+}

--- a/internal/app/gitops-commit/slackhttp/server.go
+++ b/internal/app/gitops-commit/slackhttp/server.go
@@ -1,0 +1,96 @@
+package slackhttp
+
+import (
+	"encoding/json"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"github.com/gorilla/mux"
+	"net/http"
+	"os"
+)
+
+type server struct {
+	router      *mux.Router
+	slackSecret string
+	keys        *ssh.PublicKeys
+	registry    *NamedRepositoryRegistry
+}
+
+func NewSlackCommandServer(r NamedRepositoryRegistry, keys *ssh.PublicKeys) *server {
+	s := &server{
+		router:      mux.NewRouter(),
+		keys:        keys,
+		slackSecret: os.Getenv("SLACK_SIGNING_SECRET"),
+		registry:    &r,
+	}
+
+	s.routes()
+
+	return s
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
+}
+
+func (s *server) handleHealthCheck() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI == "/ping" {
+			body, err := json.Marshal(struct {
+				Pong bool `json:"pong"`
+			}{
+				Pong: true,
+			})
+
+			if err != nil {
+				return
+			}
+
+			s.respond(w, r, body, http.StatusOK)
+
+			return
+		}
+
+		body, err := json.Marshal(struct {
+			Ok bool `json:"ok"`
+		}{
+			Ok: true,
+		})
+
+		if err != nil {
+			return
+		}
+
+		s.respond(w, r, body, http.StatusOK)
+	}
+}
+
+func (s *server) respond(w http.ResponseWriter, r *http.Request, data interface{}, status int) {
+	w.Header().Set("server", "gitops-commit")
+	w.Header().Set("content-type", "text/json")
+	w.WriteHeader(status)
+
+	if response, ok := data.([]byte); ok {
+		_, err := w.Write(response)
+		if err != nil {
+			return
+		}
+
+		return
+	}
+
+	if response, ok := data.(string); ok {
+		_, err := w.Write([]byte(response))
+		if err != nil {
+			return
+		}
+
+		return
+
+	}
+}
+
+func (s *server) handleNotFound() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}
+}


### PR DESCRIPTION
- [x] Add YAML manifests for named known configurations
- [x] Add basic slack/http integration
- [x] Add `deploy`  as sub-command, maybe with `read`
- [ ] (Optional) add the ability to lookup the latest tag?

# Manifest Example

```yaml
repositories:
  # https://github.com/gsdevme/test/blob/master/deployments/foo/values.yaml
  # https://github.com/gsdevme/test
  - name: my-app-test
    repository: gsdevme/test
    file: deployments/foo/values.yaml
    notation: foo.woo.wibble.tag
```

# Usage

Mutates the yaml to that tag
`/gitops-commit deploy [name] [tag]`

**[Nice to have]** Prints the current tag in the yaml
`/gitops-commit show [name]`

**[Nice to have]** Shows the latest tag available on the repo 
`/gitops-commit latest [name]`